### PR TITLE
docs(openspec): propose migrate-tests-to-bats change

### DIFF
--- a/openspec/changes/migrate-tests-to-bats/.openspec.yaml
+++ b/openspec/changes/migrate-tests-to-bats/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/migrate-tests-to-bats/design.md
+++ b/openspec/changes/migrate-tests-to-bats/design.md
@@ -1,0 +1,255 @@
+## Context
+
+`scripts/tests/run.sh` (294 lines, 14 distinct assertions) is the project's
+sole test surface. It runs in CI via a single line in
+`.github/workflows/ci.yml` and is intended to be runnable locally with
+`bash scripts/tests/run.sh`.
+
+The runner has accumulated load-bearing complexity that the file itself
+does not surface:
+
+- Inline mocks: a 33-line `code` CLI stub built into a `$TMP/bin` directory
+  and prepended to PATH (lines 12–48).
+- Inline fixture builders: a self-contained mini-repo built under
+  `$TMP/repo` to test compose-settings's `@extends` containment rules
+  (lines 109–117).
+- Trap chaining: an early `trap 'rm -rf "$TMP"' EXIT` is later replaced
+  with `trap 'rm -rf "$TMP" "$INJ_PROFILE_DIR"' EXIT` (line 181) to clean
+  up a fixture written into the live profiles tree.
+- Shared global env: `CODE_LOG`, `VSCODE_EXTENSION_INSTALL_DELAY`,
+  `VSCODE_SKIP_EXTENSION_INSTALL`, `VSCODE_USER_DIR` are set/unset
+  imperatively across tests; one test's leakage can silently affect the
+  next.
+- One-shot reporting: any failure calls `fail()` which exits the process,
+  hiding all subsequent failures and forcing repeated CI cycles to
+  surface them.
+
+The test surface is going to grow — the upcoming `profile-graceful-defaults`
+change adds a regression test for `import-profile.sh`'s theme-fallback
+rewrite, and the wshobson shell-testing skill recommends bats-core as the
+canonical framework. Migrating now (14 assertions) is meaningfully
+cheaper than later (uncapped growth).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace `scripts/tests/run.sh` with a bats-core suite at full coverage
+  parity.
+- Establish the test layout (`scripts/tests/bats/<concern>.bats` +
+  `scripts/tests/bats/helpers/`) as the place all future tests are added.
+- Extract reusable helpers (mocked `code` CLI, fixture-tree builders,
+  `assert_compose_rejects` and similar) into helper files loaded via
+  bats's `load`.
+- Update CI to install bats-core and invoke the suite via `bats
+  scripts/tests/bats/`.
+- Document the new contributor flow in `README.md` and `CONTRIBUTING.md`.
+
+**Non-Goals:**
+
+- Adding new test coverage. This change preserves existing assertions
+  exactly. Coverage *additions* belong in the changes that introduce the
+  features being tested (e.g., `profile-graceful-defaults`).
+- Switching to a different framework (shellspec, shunit2, custom). The
+  project's shell-testing guidance documents bats-core as the default.
+- Rewriting the production scripts under test. They are the system under
+  test, not part of the migration.
+- Parallelization of CI. Bats supports `--jobs N` and the suite is
+  parallel-safe by design (per-test `$BATS_TEST_TMPDIR`), but enabling
+  `--jobs` in CI is a separate, low-risk follow-up.
+
+## Decisions
+
+### Decision 1: bats-core over shellspec, shunit2, custom
+
+**Choice**: bats-core.
+
+**Rationale**: TAP output for CI parsing, largest ecosystem (Homebrew/nvm
+test suites use it), first-class GitHub Actions integration via
+`bats-core/bats-action`, parallel execution, active maintenance. The
+project's `artagon-shell:shell-testing` and
+`wshobson-shell-scripting--bats-testing-patterns` skills both name
+bats-core as the default.
+
+**Alternatives considered**:
+
+- *shellspec*: better mocking, broader shell support (dash, ksh, zsh).
+  All the production scripts are bash with `#!/usr/bin/env bash`, so
+  cross-shell support is unused; the BDD syntax adds learning cost
+  without proportional benefit here.
+- *shunit2*: deprecated in the shell-testing skill; no TAP, no parallel
+  execution, last release 2020.
+- *Stay on `run.sh` and refactor it*: the file would need an assertion
+  registry, a per-test isolation model, and TAP output — i.e., reinvent
+  bats. Not worth it.
+
+### Decision 2: One `.bats` file per logical concern, not per script
+
+**Choice**: file boundaries follow the concerns in `run.sh` (validate,
+compose, export, open, install-extensions, extension-id-allowlist,
+import-profile, symlink-invariants, workspace-trust), not the production
+scripts under test.
+
+**Rationale**: tests in `run.sh` already cluster by concern. Multiple
+scripts (e.g., extension-id allowlist) participate in a single test —
+splitting by script would require duplicating the test or arbitrarily
+choosing a "primary" script.
+
+**Alternatives considered**:
+
+- *One `.bats` per production script*: forces unnatural test placement
+  for cross-script concerns.
+- *One giant `.bats`*: defeats bats's per-file `setup_file` lifecycle
+  and makes parallel-by-file execution useless.
+
+### Decision 3: Helpers extracted into `helpers/`
+
+**Choice**: three helper files —
+`helpers/setup.bash` (ROOT detection, common env), `helpers/mock-code-cli.bash`
+(the `code` stub), `helpers/assertions.bash` (`assert_compose_rejects`
+and similar).
+
+**Rationale**: the mocked `code` CLI is needed by at least four `.bats`
+files (open, install-extensions, extension-id, import-profile).
+Duplicating its 33 lines across files is exactly the maintenance burden
+the migration is supposed to eliminate.
+
+**Alternatives considered**:
+
+- *Inline the stub in each file*: rejected; duplication.
+- *Use `bats-mock`*: full mocking framework, but our needs are limited to
+  one stub. Adding a vendored dependency for one stub is overkill.
+
+### Decision 4: Side-by-side migration, then delete in the same change
+
+**Choice**: keep `scripts/tests/run.sh` running in CI alongside the
+growing bats suite during migration. Delete `run.sh` and switch CI to
+bats only as the final task.
+
+**Rationale**: this mirrors the
+spec's "Coverage parity" requirement — every assertion in `run.sh` must
+have a bats counterpart before deletion. Running both lets us spot a
+bats test that *passes* when its `run.sh` counterpart *fails*, which
+would be a silent coverage regression.
+
+**Alternatives considered**:
+
+- *Big-bang switchover*: faster but riskier; a missed assertion lands
+  silently.
+- *Two changes (add bats, then delete `run.sh`)*: the spec explicitly
+  forbids this — a "cleanup" follow-up is rejected because it almost
+  always slips and lets two test surfaces coexist indefinitely.
+
+### Decision 5: Tighten exit-code assertions during migration
+
+**Choice**: each bats test asserts a *specific* exit code (`[ "$status" -eq 1 ]`,
+`[ "$status" -eq 0 ]`, etc.) — not the looser `-ne 0` pattern that `run.sh`
+uses (`run.sh:130, 190, 208, 216`).
+
+**Rationale**: the
+`artagon-shell:shell-testing` and `wshobson-shell-scripting--bats-testing-patterns`
+skills both call this out: "Exit codes matter — explicitly assert
+`[ "$status" -eq N ]` rather than just `[ "$status" -ne 0 ]`." Preserving
+the loose check would carry forward a known weak assertion. The cost is
+modest: each migrating test author looks up the actual exit code (most
+production scripts use plain `exit 1` for failure paths) and writes
+the specific number.
+
+**Alternatives considered**:
+
+- *Strict parity (`-ne 0`)*: simpler migration but inherits a known weak
+  assertion. The migration is the natural moment to tighten.
+- *Defer to a follow-up*: would mean a third PR after the side-by-side
+  delete. Adds a fourth PR to the bounded window in the migration plan.
+
+### Decision 6: bats-core install in CI via `bats-core/bats-action`
+
+**Choice**: use the official `bats-core/bats-action@3.0.0` GitHub Action
+in CI. For local install, document `brew install bats-core`,
+`apt install bats`, and `npm install -g bats`.
+
+**Rationale**: it's the canonical install path documented by
+bats-core. Vendoring bats into the repo (via `git submodule` or copy)
+adds maintenance burden for negligible benefit.
+
+**Alternatives considered**:
+
+- *Vendor bats-core (copy or submodule)*: the wshobson skill mentions
+  this as an option. Either form adds a maintenance burden — keeping
+  the vendored copy current with upstream — for negligible benefit
+  over the install action. Net cost > net benefit.
+
+## Risks / Trade-offs
+
+- **[Coverage regression during migration]** A bats test could pass
+  while its `run.sh` counterpart fails (or vice versa) due to subtle
+  isolation differences. → Mitigation: run both suites in CI for the
+  duration of the migration. The parity-checkpoint task explicitly
+  cross-references each `run.sh` assertion to a bats file:test-name
+  before allowing `run.sh` deletion.
+
+- **[Mocked `code` CLI behavior drift]** If a `.bats` file forgets to
+  load `helpers/mock-code-cli.bash`, the test will accidentally invoke
+  the real `code` if installed (or fail confusingly if not). →
+  Mitigation: helpers' `setup_file` always loads the mock and fails
+  fast if PATH does not include the stub directory.
+
+- **[Trap-equivalent cleanup in bats]** `run.sh` uses `trap` for
+  cleanup; bats uses `teardown`. The fixture written under
+  `profiles/$INJ_PROFILE_NAME` (lines 177–219 of `run.sh`) writes into
+  the *live* profiles tree, not into `$TMP`. Bats `teardown` runs even
+  on test failure, but if the test process is killed (Ctrl-C), the
+  fixture leaks. → Mitigation: rewrite the injection-allowlist test to
+  use a temp dir under `$BATS_TEST_TMPDIR` with a stub `ROOT`
+  override, eliminating the live-tree fixture entirely. This is the
+  one place migration improves on `run.sh` rather than preserving it.
+
+- **[Contributor friction]** Local test runs now require `bats-core`
+  installed. → Mitigation: install steps in `CONTRIBUTING.md`; the CI
+  workflow already does the install, so a contributor who runs `gh
+  workflow run` instead can sidestep the local install.
+
+- **[Bats-version drift between local and CI]** Different bats-core
+  versions can have subtly different `run`/`status`/`output`
+  semantics. → Mitigation: pin
+  `bats-core/bats-action@3.0.0` in CI; document a minimum local
+  version in `CONTRIBUTING.md`.
+
+## Migration Plan
+
+The migration is structured so CI is *always* green:
+
+1. Add bats-core install + bats invocation to CI **alongside** the
+   existing `bash scripts/tests/run.sh` step. CI runs both. (Initial
+   bats suite is empty; the step is a no-op pass.)
+2. Land the helpers (`setup.bash`, `mock-code-cli.bash`,
+   `assertions.bash`).
+3. Migrate each concern in its own commit (or PR slice if the project
+   prefers): `validate-json.bats`, then `compose-settings.bats`, etc.
+4. Parity-checkpoint task: produce a markdown table mapping every
+   numbered assertion 1–14 in the spec's "Coverage parity" requirement
+   to a bats `file:test-name`. The table lives in the change directory
+   (`openspec/changes/migrate-tests-to-bats/parity.md`) and is reviewed
+   by a human before deletion.
+5. Delete `scripts/tests/run.sh` and remove its CI step in the same
+   commit.
+6. Update `README.md` and `CONTRIBUTING.md`.
+
+**Bounded window**: the side-by-side state ends within three PRs of
+the helpers PR merging — helpers PR, all-tests PR, parity-and-delete
+PR. If the migration cannot fit that envelope it pauses for a
+re-scoping discussion rather than letting two test surfaces coexist
+indefinitely.
+
+**Rollback**: if the bats suite proves problematic post-merge, revert
+the deletion commit. The earlier commits (helpers + per-concern
+migrations) are net additions and don't need to roll back.
+
+## Open Questions
+
+- *Should bats run with `--jobs N` in CI?* Defer to a follow-up;
+  parallel-safety is built in but verifying it across all 9 files takes
+  one extra CI cycle. Land sequential first.
+- *Pin bats version locally?* `CONTRIBUTING.md` will document a
+  minimum version. Strict pinning (e.g., `.bats-version` file) seems
+  premature.

--- a/openspec/changes/migrate-tests-to-bats/proposal.md
+++ b/openspec/changes/migrate-tests-to-bats/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+`scripts/tests/run.sh` is a 294-line hand-rolled test runner that covers
+fourteen distinct assertions (enumerated in the test-suite spec): composer path-containment (5 sub-cases),
+extension-id allowlist on three call paths, PROFILE_ID generator fallback,
+symlink-leaf invariant, workspace-trust default, mocked `code` CLI logging,
+cache-skip behavior, and group-filtered installs. The runner provides no
+test isolation (one shared `$TMP`, all tests share global env), no
+per-test reporting (failure prints a single line and exits, hiding which
+later tests would also have failed), no parallel execution, and no
+structured output for CI to parse. It also bundles fixture builders, mocks,
+assertion helpers, and the runner control flow into one file — anyone
+adding a test today must read all 294 lines first.
+
+Bats-core is the canonical bash test framework: TAP output for CI, per-test
+isolation via `$BATS_TEST_TMPDIR`, parallel execution, dedicated mocking
+patterns, and a `setup`/`teardown` lifecycle that mirrors xUnit. Migrating
+now is cheap (12 test cases) and unblocks every future test — including
+the regression test for `profile-graceful-defaults` (separate change) — to
+be written in a framework rather than wedged into a growing monolith.
+
+## What Changes
+
+- Add bats-core as a project test dependency. Vendor or document install
+  (Homebrew/apt/npm) and add a CI step.
+- Create `scripts/tests/bats/` with one `.bats` file per logical concern:
+  - `validate-json.bats` — JSON/JSONC validation pass.
+  - `compose-settings.bats` — compose runs and produces symlinks; merge
+    semantics; `@extends` path-containment cases (traversal, absolute,
+    home-prefixed, malformed value, cycle through symlink).
+  - `export-profiles.bats` — exports produce non-empty bundles.
+  - `open-profiles.bats` — open invokes mocked `code` once per profile;
+    cache-skip behavior on second invocation.
+  - `install-extensions.bats` — group filter (`--group AI`) installs only
+    AI-classified extensions.
+  - `extension-id-allowlist.bats` — injection-shaped IDs rejected by all
+    three call paths (`install-extensions.sh`, `import-profile.sh`,
+    `vspcli --install-ext`).
+  - `import-profile.bats` — PROFILE_ID generator: openssl→python3
+    fallback when openssl is broken; safe under `set -euo pipefail`.
+  - `symlink-invariants.bats` — `<stack>-{crisp,retina}.jsonc` leaves
+    remain symlinks to `<stack>-base.jsonc`; spec-regex literal present
+    verbatim in capability spec docs.
+  - `workspace-trust.bats` — every merged profile has
+    `security.workspace.trust.untrustedFiles = "prompt"`.
+- Create `scripts/tests/bats/helpers/`:
+  - `setup.bash` — shared `setup_file` for ROOT detection and PATH-stub
+    bootstrap; per-test `setup`/`teardown` helpers.
+  - `mock-code-cli.bash` — extracted `code` CLI stub (current lines
+    15–47 of `run.sh`) reusable across tests.
+  - `assertions.bash` — `assert_compose_rejects` and other shared
+    assertion helpers.
+- Update `.github/workflows/ci.yml`: replace
+  `bash scripts/tests/run.sh` with a `bats scripts/tests/bats/` step,
+  preceded by a bats-core install step (use `bats-core/bats-action` or
+  `npm install -g bats`).
+- Delete `scripts/tests/run.sh` after the bats suite is at parity. The
+  deletion is the final task, not the first — keep both running side
+  by side during migration.
+- **BREAKING for contributors**: developers running tests locally must
+  install `bats-core`. Document in `README.md` and `CONTRIBUTING.md`.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-suite`: defines the project's test framework choice
+  (bats-core), test layout under `scripts/tests/bats/`, helper
+  conventions (`setup.bash`, `mock-code-cli.bash`, `assertions.bash`),
+  CI invocation, and the parity guarantee that every assertion in the
+  legacy `scripts/tests/run.sh` has an equivalent bats test before the
+  legacy runner is deleted.
+
+### Modified Capabilities
+
+(none — the legacy runner has no spec; this change introduces the
+first spec for testing.)
+
+## Impact
+
+- **Code**: `scripts/tests/bats/**` (new), `scripts/tests/run.sh` (deleted),
+  `.github/workflows/ci.yml` (CI invocation), `README.md`,
+  `CONTRIBUTING.md`.
+- **Dependencies**: new — `bats-core` (required to run tests locally and
+  in CI). No runtime/production dependency added; tests-only.
+- **APIs**: none.
+- **Backwards compatibility**: contributor-facing only. CI step changes;
+  local test invocation changes from `bash scripts/tests/run.sh` to
+  `bats scripts/tests/bats/`. No behavior of any production script is
+  modified.
+- **Risk**: medium. The current suite contains fiddly assertions
+  (PROFILE_ID hex shape, mocked-CLI invocation counts, fixture-tree
+  builds, extension-id injection across three call paths) that must be
+  preserved exactly. A faithful migration is more work than a clean-slate
+  rewrite would be — and a clean-slate rewrite would lose coverage
+  silently. Mitigation: the parity-checkpoint task requires every
+  current `run.sh` assertion to have a corresponding bats test before
+  `run.sh` is deleted.

--- a/openspec/changes/migrate-tests-to-bats/specs/test-suite/spec.md
+++ b/openspec/changes/migrate-tests-to-bats/specs/test-suite/spec.md
@@ -26,16 +26,28 @@ prerequisite in `README.md` and `CONTRIBUTING.md`.
 Tests MUST live under `scripts/tests/bats/` with one `.bats` file per
 logical concern. Shared fixtures, mocks, and assertion helpers MUST live
 under `scripts/tests/bats/helpers/` and be loaded via bats's `load`
-directive. Tests MUST NOT depend on writeable state outside their per-test
-`$BATS_TEST_TMPDIR`, except for the read-only repository tree itself.
+directive.
+
+Tests MUST scope new state to their per-test `$BATS_TEST_TMPDIR`
+whenever feasible. Some production scripts under test
+(`compose-settings.sh`, `export-profiles.sh`) intentionally write to
+the working tree (`_merged/`, `exports/`, profile symlinks); tests that
+exercise those scripts MAY allow them to write to the working tree, but
+the suite as a whole MUST leave the working tree in the same state it
+started in — verified by `git status --porcelain` returning empty after
+the suite runs to completion. This means either (a) tests run scripts
+against a temp repo copy under `$BATS_TEST_TMPDIR`, or (b) tests run
+scripts against the live repo and either teardown reverts the writes
+or `git checkout -- <paths>` restores them. Either approach is
+permitted; the test author chooses.
 
 #### Scenario: Test isolation leaves no residue in the working tree
 
 - **WHEN** the bats suite runs to completion (pass or fail) from a clean
   working tree
-- **THEN** `git status --porcelain` shows no new or modified files outside
-  the source-controlled set — i.e., all per-test mutations were scoped to
-  `$BATS_TEST_TMPDIR` and cleaned up on teardown
+- **THEN** `git status --porcelain` shows no new or modified files
+  outside the source-controlled set — regardless of which isolation
+  strategy individual tests used (temp copy vs live + restore)
 
 #### Scenario: Helper reuse
 
@@ -102,13 +114,16 @@ corresponding bats test (or a documented superseding test):
 
 The migration MUST include an executable parity verifier — not only a
 manual review — for the duration of the side-by-side period. The
-verifier reads `openspec/changes/migrate-tests-to-bats/parity.md`,
-parses each numbered row's bats `file:test-name` reference, and asserts
-that the file exists and contains a `@test` declaration with that exact
-name. The verifier MUST exit non-zero on any mismatch. CI MUST run the
-verifier on every PR while the migration is in flight. The verifier and
-its CI step are removed in the same commit that deletes
-`scripts/tests/run.sh`.
+parity file `openspec/changes/migrate-tests-to-bats/parity.md` MUST
+use a fixed-shape line format (one assertion per line matching
+`^N\. <file>:<test-name>$`, where N is 1–14). Lines that don't match
+the regex are ignored as commentary. The verifier reads `parity.md`,
+extracts each numbered line's bats `file:test-name` reference, and
+asserts that the file exists and contains a `@test` declaration with
+that exact name. The verifier MUST exit non-zero on any mismatch. CI
+MUST run the verifier on every PR while the migration is in flight.
+The verifier and its CI step are removed in the same commit that
+deletes `scripts/tests/run.sh`.
 
 #### Scenario: Verifier catches a missing bats test
 
@@ -118,9 +133,9 @@ its CI step are removed in the same commit that deletes
 - **THEN** the verifier exits non-zero with a message naming the
   missing pair, and CI fails
 
-#### Scenario: Verifier passes on a complete table
+#### Scenario: Verifier passes on a complete parity file
 
-- **WHEN** every numbered row in `parity.md` resolves to an existing
+- **WHEN** every numbered line in `parity.md` resolves to an existing
   `@test` in the named bats file
 - **THEN** the verifier exits 0
 

--- a/openspec/changes/migrate-tests-to-bats/specs/test-suite/spec.md
+++ b/openspec/changes/migrate-tests-to-bats/specs/test-suite/spec.md
@@ -1,0 +1,178 @@
+## ADDED Requirements
+
+### Requirement: Test framework
+
+The project SHALL use bats-core as its sole shell-script test framework.
+Tests written in any other framework (raw bash runners, shunit2, shellspec)
+MUST NOT be checked in. The project MUST document bats-core as a contributor
+prerequisite in `README.md` and `CONTRIBUTING.md`.
+
+#### Scenario: Contributor runs tests locally
+
+- **WHEN** a contributor with bats-core installed runs `bats scripts/tests/bats/`
+  from the repository root
+- **THEN** every test in `scripts/tests/bats/*.bats` executes and the runner
+  exits 0 if and only if all tests pass
+
+#### Scenario: bats-core not installed
+
+- **WHEN** a contributor without bats-core attempts to run the suite
+- **THEN** they receive a clear error from the system
+  (`bats: command not found`) and `CONTRIBUTING.md` documents the install
+  steps for macOS, Debian/Ubuntu, and npm
+
+### Requirement: Test layout
+
+Tests MUST live under `scripts/tests/bats/` with one `.bats` file per
+logical concern. Shared fixtures, mocks, and assertion helpers MUST live
+under `scripts/tests/bats/helpers/` and be loaded via bats's `load`
+directive. Tests MUST NOT depend on writeable state outside their per-test
+`$BATS_TEST_TMPDIR`, except for the read-only repository tree itself.
+
+#### Scenario: Test isolation leaves no residue in the working tree
+
+- **WHEN** the bats suite runs to completion (pass or fail) from a clean
+  working tree
+- **THEN** `git status --porcelain` shows no new or modified files outside
+  the source-controlled set — i.e., all per-test mutations were scoped to
+  `$BATS_TEST_TMPDIR` and cleaned up on teardown
+
+#### Scenario: Helper reuse
+
+- **WHEN** more than one `.bats` file needs the mocked `code` CLI stub
+- **THEN** the stub lives in `scripts/tests/bats/helpers/mock-code-cli.bash`
+  and is loaded via `load helpers/mock-code-cli` rather than duplicated
+
+### Requirement: Coverage parity with legacy runner
+
+The bats suite MUST cover every assertion present in
+`scripts/tests/run.sh` at the time of migration. The migration is not
+complete and `scripts/tests/run.sh` MUST NOT be deleted until a
+parity-checkpoint task verifies that each numbered assertion below has a
+corresponding bats test (or a documented superseding test):
+
+1. `validate-json.sh` exits 0 on the live tree.
+2. `compose-settings.sh` exits 0 on the live tree.
+3. `profiles/java-profile-crisp/settings.json` is a symlink after compose.
+4. `export-profiles.sh` produces a non-empty
+   `exports/java-profile-crisp.code-profile`.
+5. `open-profiles.sh` invokes the mocked `code` CLI exactly once per
+   profile (with `VSCODE_SKIP_EXTENSION_INSTALL=1`).
+6. The cache layer in `open-profiles.sh` skips installs on the second
+   invocation when the cache hash matches.
+7. `install-extensions.sh ... --group AI` installs only AI-classified
+   extensions (count derived from the profile's `extensions.json`).
+8. `compose-settings.sh` rejects `@extends` traversal paths
+   (`../../../etc/passwd`), absolute paths (`/tmp/evil.jsonc`),
+   home-prefixed paths (`~/secret.jsonc`), malformed `@extends` values
+   (non-string, non-array), and cycles introduced via symlink.
+9. `install-extensions.sh`, `import-profile.sh`, and `vspcli --install-ext`
+   each reject extension IDs containing shell injection metacharacters
+   with a `rejected extension id` message and a non-zero exit.
+10. The `import-profile.sh` PROFILE_ID generator falls back to
+    `python3 -c 'import secrets; print(secrets.token_hex(4))'` when
+    `openssl rand -hex 4` fails on PATH, and produces an 8-char lowercase
+    hex string.
+11. The `import-profile.sh` PROFILE_ID generator runs cleanly under
+    `set -euo pipefail`.
+12. The `EXTENSION_ID_REGEX` literal in `scripts/lib/extension-id.sh`
+    appears verbatim in the live capability specs for
+    `install-profile-extensions`, `import-profile-bundles`, and
+    `manage-profile-cli`. The bats test MUST resolve each capability's
+    spec by checking `openspec/specs/<cap>/spec.md` first, then falling
+    back to the still-active change folder
+    `openspec/changes/harden-profile-tooling-and-pipeline/specs/<cap>/spec.md`.
+    This makes the test resilient to that change being archived
+    (post-archive, the canonical location moves from `changes/` to
+    `specs/`).
+13. Every `<stack>-{crisp,retina}.jsonc` leaf under `_overrides/` for
+    `java-{gradle,maven,profile,spring}` and `rust-profile` is a symlink
+    pointing to `<stack>-base.jsonc`.
+14. Every merged JSON file in `_merged/` has
+    `security.workspace.trust.untrustedFiles == "prompt"`.
+
+#### Scenario: Parity check before legacy deletion
+
+- **WHEN** the migration's parity-checkpoint task runs
+- **THEN** every assertion 1–14 above is mapped to a bats test (file +
+  test name), and any unmapped assertion blocks deletion of
+  `scripts/tests/run.sh`
+
+### Requirement: Mechanized parity verification
+
+The migration MUST include an executable parity verifier — not only a
+manual review — for the duration of the side-by-side period. The
+verifier reads `openspec/changes/migrate-tests-to-bats/parity.md`,
+parses each numbered row's bats `file:test-name` reference, and asserts
+that the file exists and contains a `@test` declaration with that exact
+name. The verifier MUST exit non-zero on any mismatch. CI MUST run the
+verifier on every PR while the migration is in flight. The verifier and
+its CI step are removed in the same commit that deletes
+`scripts/tests/run.sh`.
+
+#### Scenario: Verifier catches a missing bats test
+
+- **WHEN** `parity.md` claims assertion N is covered by
+  `<file>.bats:<test-name>` but `<file>.bats` either does not exist or
+  contains no `@test "<test-name>"` declaration
+- **THEN** the verifier exits non-zero with a message naming the
+  missing pair, and CI fails
+
+#### Scenario: Verifier passes on a complete table
+
+- **WHEN** every numbered row in `parity.md` resolves to an existing
+  `@test` in the named bats file
+- **THEN** the verifier exits 0
+
+### Requirement: Shell-script linting
+
+The CI workflow MUST run `shellcheck` against every `*.sh` under
+`scripts/` and every `*.bash` helper under
+`scripts/tests/bats/helpers/`. The lint step MUST fail the build on
+any warning at severity `--severity=warning` or higher. Helper files
+MUST declare their shell dialect via a `# shellcheck shell=bash`
+directive at the top of the file (helpers are sourced, not run, so
+shellcheck cannot infer dialect from a shebang). The shellcheck step
+is independent of the bats migration and persists after
+`scripts/tests/run.sh` is deleted.
+
+#### Scenario: New script with shellcheck violation blocks merge
+
+- **WHEN** a pull request adds a `*.sh` script with a shellcheck
+  warning (e.g., SC2086 unquoted variable expansion)
+- **THEN** the CI shellcheck step exits non-zero and the PR cannot
+  merge until the warning is resolved or explicitly disabled with a
+  justified `# shellcheck disable=SC2086` directive
+
+#### Scenario: Helper without shell directive is rejected
+
+- **WHEN** a new file under `scripts/tests/bats/helpers/*.bash` lacks
+  the `# shellcheck shell=bash` directive
+- **THEN** shellcheck either skips the file (no lint coverage —
+  silent regression) or warns about missing dialect declaration. The
+  CI configuration MUST treat the latter as a failure
+
+### Requirement: CI invocation
+
+The CI workflow MUST install bats-core before running tests and MUST
+invoke the suite via `bats scripts/tests/bats/` (not via the legacy
+runner) once the migration is complete. CI MUST fail on any failing test.
+
+#### Scenario: CI runs the bats suite
+
+- **WHEN** a pull request triggers `.github/workflows/ci.yml`
+- **THEN** the workflow installs bats-core, runs `bats scripts/tests/bats/`,
+  and the job fails if any test reports non-zero exit
+
+### Requirement: Legacy runner deletion
+
+`scripts/tests/run.sh` MUST be deleted as the final task of the
+migration, only after the parity-checkpoint passes. Deletion MUST be
+in the same change as the bats suite landing — a follow-up "cleanup"
+change is NOT acceptable.
+
+#### Scenario: Legacy runner removed at parity
+
+- **WHEN** the migration completes
+- **THEN** `scripts/tests/run.sh` no longer exists in the repository,
+  and `.github/workflows/ci.yml` no longer references it

--- a/openspec/changes/migrate-tests-to-bats/tasks.md
+++ b/openspec/changes/migrate-tests-to-bats/tasks.md
@@ -1,0 +1,58 @@
+## 1. CI bootstrap (both runners green + linting)
+
+- [ ] 1.1 Add `bats-core/bats-action@3.0.0` install step to `.github/workflows/ci.yml` ahead of the existing `bash scripts/tests/run.sh` step.
+- [ ] 1.2 Add `bats scripts/tests/bats/` invocation step after the install. Suite is empty at this point — the step is a no-op pass and proves the CI integration works.
+- [ ] 1.3 Add a `shellcheck` CI step that lints every `*.sh` under `scripts/` plus every `*.bash` helper under `scripts/tests/bats/helpers/`. Use `ludeeus/action-shellcheck@master` or equivalent. Configure to pass `--severity=warning` initially; tighten to `--severity=style` post-migration. The shellcheck step is a permanent addition (does not get removed alongside `run.sh` in §5).
+- [ ] 1.4 Verify CI is green on a draft PR: `run.sh`, empty bats step, and shellcheck all pass.
+
+## 2. Test layout and helpers
+
+- [ ] 2.1 Create `scripts/tests/bats/` and `scripts/tests/bats/helpers/`.
+- [ ] 2.2 Write `helpers/setup.bash`: exports `ROOT`, sets `VSCODE_EXTENSION_INSTALL_DELAY=0`, defines a per-test `make_tmp_root` helper for tests that need a sibling `scripts/_shared/_overrides/profiles` fixture tree under `$BATS_TEST_TMPDIR`. **Shell hygiene**: every helper file starts with `# shellcheck shell=bash` (the file is sourced, not run, so shellcheck cannot infer dialect from a shebang). Bats helpers do not get a shebang.
+- [ ] 2.3 Write `helpers/mock-code-cli.bash`: extracts the `code` CLI stub from `run.sh:15-47` into a reusable function `install_mock_code_cli` that takes a target dir, writes the stub, prepends to PATH, sets `CODE_LOG`. Add a fail-fast check that PATH starts with the mock dir. Same `# shellcheck shell=bash` directive at top.
+- [ ] 2.4 Write `helpers/assertions.bash`: extract `assert_compose_rejects` from `run.sh:123-132` and any other shared assertions discovered during migration. Same `# shellcheck shell=bash` directive at top.
+- [ ] 2.5 Pin a minimum bats version in `CONTRIBUTING.md` (target the version installed by `bats-core/bats-action@3.0.0`).
+- [ ] 2.6 Confirm all helper files clear `shellcheck` (the §1.3 CI step covers this on PR; verify locally first via `shellcheck scripts/tests/bats/helpers/*.bash`).
+
+## 3. Migrate per-concern (each task = one `.bats` file at parity)
+
+For each `.bats` file: write the file, run `bats <file>` locally, confirm it passes; then on CI, confirm both `run.sh` (which still has the same assertion) and the new bats test pass for the same logical case.
+
+- [ ] 3.1 `scripts/tests/bats/validate-json.bats` — covers `run.sh:56-57` (assertion #1).
+- [ ] 3.2 `scripts/tests/bats/compose-settings.bats` — covers `run.sh:59-63, 105-165` (assertions #2, #3, #8 with all 5 sub-cases). Use `make_tmp_root` for the `@extends` containment fixtures.
+- [ ] 3.3 `scripts/tests/bats/export-profiles.bats` — covers `run.sh:65-69` (assertion #4).
+- [ ] 3.4 `scripts/tests/bats/open-profiles.bats` — covers `run.sh:71-83, 94-103` (assertions #5, #6). Loads `mock-code-cli.bash`.
+- [ ] 3.5 `scripts/tests/bats/install-extensions.bats` — covers `run.sh:85-92` (assertion #7). Loads `mock-code-cli.bash`.
+- [ ] 3.6 `scripts/tests/bats/extension-id-allowlist.bats` — covers `run.sh:167-219` (assertion #9) across all three call paths (`install-extensions.sh`, `import-profile.sh`, `vspcli --install-ext`). **Isolation pattern**: production scripts use a fixed `ROOT="$(cd "$(dirname "$0")/.." && pwd)"` and have no env override. Use the existing `cp` pattern from `run.sh:114` — copy each script into `$BATS_TEST_TMPDIR/repo/scripts/` and build a minimal sibling tree (`scripts/lib/extension-id.sh`, `profiles/<fixture>/extensions.json`). This eliminates the `INJ_PROFILE_DIR` write into the live `profiles/` tree (`run.sh:177-181`) without modifying any production script (preserves the design.md non-goal "Rewriting the production scripts under test"). Verify post-test that `git status --porcelain` shows no changes.
+- [ ] 3.7 `scripts/tests/bats/import-profile.bats` — covers `run.sh:221-255` (assertions #10, #11). Stubs a broken `openssl` ahead of the real one; verifies python3 fallback and `set -euo pipefail` safety.
+- [ ] 3.8 `scripts/tests/bats/symlink-invariants.bats` — covers `run.sh:257-279` (assertions #12, #13). Pure repo-state assertions, no fixtures needed. **Pre-write check for #12**: `harden-profile-tooling-and-pipeline` may have been archived between proposal and implementation. Resolve each capability spec via the spec's documented order: try `openspec/specs/<cap>/spec.md` first; on miss fall back to `openspec/changes/harden-profile-tooling-and-pipeline/specs/<cap>/spec.md`. Implement this fallback in the bats test itself (not in a one-shot path lookup) so future archives don't break it.
+- [ ] 3.9 `scripts/tests/bats/workspace-trust.bats` — covers `run.sh:281-291` (assertion #14). Runs `compose-settings.sh` first to populate `_merged/`, then asserts.
+
+## 4. Parity checkpoint (mechanized + manual)
+
+- [ ] 4.1 Produce `openspec/changes/migrate-tests-to-bats/parity.md`: a table with one row per numbered assertion 1–14 from `specs/test-suite/spec.md` "Coverage parity" requirement, mapping each to `scripts/tests/bats/<file>:<test-name>`. Cross-check against `run.sh` line numbers.
+- [ ] 4.2 Write the parity verifier per the spec's "Mechanized parity verification" requirement. **Format constraint**: `parity.md` MUST use a fixed-shape line format (e.g., one assertion per line, `^N\. <file>:<test-name>$`) so the verifier can parse with a single regex and not reinvent markdown-table parsing. **Implementation choice**: prefer `scripts/tests/check-parity.sh` (bash) only if it stays under the shell-authoring 100-line threshold; otherwise write `scripts/tests/check-parity.py` (Python 3, stdlib only — no new dependency). Either way: must exit non-zero on any miss, must obey `#!/usr/bin/env bash` or `#!/usr/bin/env python3` shebang, must clear `shellcheck`/`ruff` respectively. Add a CI step that runs this verifier ahead of `bats scripts/tests/bats/`. (Removed in §5 when `run.sh` is deleted.)
+- [ ] 4.3 Manual review: a maintainer confirms the table semantically captures every `run.sh` assertion (the verifier proves *file+name resolve*; only a human can confirm the *test logic* matches the original). This is the gate for §5.
+- [ ] 4.4 Verify bats suite passes under `--jobs 4` (parallel-safety check) at least once locally; do not enable in CI yet.
+
+## 4b. Timing constraint
+
+- [ ] 4b.1 The side-by-side period (where both `run.sh` and bats run in CI) MUST end within three PRs after the helpers PR (§2) merges: helpers PR, all-tests PR, parity-and-delete PR. If the migration cannot fit that envelope, pause and discuss before continuing — drift is the failure mode this constraint exists to prevent.
+
+## 5. Cut over
+
+- [ ] 5.1 Remove the `bash scripts/tests/run.sh` step from `.github/workflows/ci.yml`.
+- [ ] 5.2 Remove the parity-verifier invocation step from `.github/workflows/ci.yml` and delete `scripts/tests/check-parity.sh` (or `check-parity.py`, whichever was chosen in §4.2). The verifier was a migration aid; with `run.sh` gone there is no parity to verify. **Note**: the shellcheck CI step from §1.3 is permanent and stays.
+- [ ] 5.3 Delete `scripts/tests/run.sh`. Same commit as 5.1 and 5.2.
+- [ ] 5.4 Verify CI is green on a fresh PR with bats-only.
+
+## 6. Documentation
+
+- [ ] 6.1 `README.md`: update any "Run tests with …" line to `bats scripts/tests/bats/`.
+- [ ] 6.2 `CONTRIBUTING.md`: add a "Running tests" section with bats-core install steps for macOS (`brew install bats-core`), Debian/Ubuntu (`apt install bats`), and npm (`npm install -g bats`). Mention the minimum version pinned in §2.5. Also add a "Shell scripts" section noting: `set -euo pipefail` + `IFS=$'\n\t'` preamble; `[[ … ]]` over `[ … ]`; cite `shellcheck` SC-codes (link pattern `https://www.shellcheck.net/wiki/SC<N>`) in review comments; helper files use `# shellcheck shell=bash` directive in lieu of shebang.
+- [ ] 6.3 `agents/` docs: if any LLM-facing doc references `scripts/tests/run.sh`, update to `scripts/tests/bats/`.
+
+## 7. Validate the change
+
+- [ ] 7.1 Run `openspec validate migrate-tests-to-bats --strict` and resolve any findings.
+- [ ] 7.2 Open the PR; ensure the parity table at §4.1 is linked in the description.

--- a/openspec/changes/migrate-tests-to-bats/tasks.md
+++ b/openspec/changes/migrate-tests-to-bats/tasks.md
@@ -1,8 +1,8 @@
 ## 1. CI bootstrap (both runners green + linting)
 
-- [ ] 1.1 Add `bats-core/bats-action@3.0.0` install step to `.github/workflows/ci.yml` ahead of the existing `bash scripts/tests/run.sh` step.
+- [ ] 1.1 Add `bats-core/bats-action` install step to `.github/workflows/ci.yml` ahead of the existing `bash scripts/tests/run.sh` step. **Pin to a full commit SHA**, not a tag (e.g., `bats-core/bats-action@<full-40-char-sha> # v3.0.0`). Matches the existing CI pattern at `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`. Resolve the SHA from the bats-action release notes at the time of implementation.
 - [ ] 1.2 Add `bats scripts/tests/bats/` invocation step after the install. Suite is empty at this point — the step is a no-op pass and proves the CI integration works.
-- [ ] 1.3 Add a `shellcheck` CI step that lints every `*.sh` under `scripts/` plus every `*.bash` helper under `scripts/tests/bats/helpers/`. Use `ludeeus/action-shellcheck@master` or equivalent. Configure to pass `--severity=warning` initially; tighten to `--severity=style` post-migration. The shellcheck step is a permanent addition (does not get removed alongside `run.sh` in §5).
+- [ ] 1.3 Add a `shellcheck` CI step that lints every `*.sh` under `scripts/` plus every `*.bash` helper under `scripts/tests/bats/helpers/`. Use `ludeeus/action-shellcheck` **pinned to a full commit SHA**, not `@master` (which is a moving target — `@master` is forbidden by the repo's supply-chain convention). Configure to pass `--severity=warning` initially; tighten to `--severity=style` post-migration. The shellcheck step is a permanent addition (does not get removed alongside `run.sh` in §5).
 - [ ] 1.4 Verify CI is green on a draft PR: `run.sh`, empty bats step, and shellcheck all pass.
 
 ## 2. Test layout and helpers
@@ -30,9 +30,9 @@ For each `.bats` file: write the file, run `bats <file>` locally, confirm it pas
 
 ## 4. Parity checkpoint (mechanized + manual)
 
-- [ ] 4.1 Produce `openspec/changes/migrate-tests-to-bats/parity.md`: a table with one row per numbered assertion 1–14 from `specs/test-suite/spec.md` "Coverage parity" requirement, mapping each to `scripts/tests/bats/<file>:<test-name>`. Cross-check against `run.sh` line numbers.
-- [ ] 4.2 Write the parity verifier per the spec's "Mechanized parity verification" requirement. **Format constraint**: `parity.md` MUST use a fixed-shape line format (e.g., one assertion per line, `^N\. <file>:<test-name>$`) so the verifier can parse with a single regex and not reinvent markdown-table parsing. **Implementation choice**: prefer `scripts/tests/check-parity.sh` (bash) only if it stays under the shell-authoring 100-line threshold; otherwise write `scripts/tests/check-parity.py` (Python 3, stdlib only — no new dependency). Either way: must exit non-zero on any miss, must obey `#!/usr/bin/env bash` or `#!/usr/bin/env python3` shebang, must clear `shellcheck`/`ruff` respectively. Add a CI step that runs this verifier ahead of `bats scripts/tests/bats/`. (Removed in §5 when `run.sh` is deleted.)
-- [ ] 4.3 Manual review: a maintainer confirms the table semantically captures every `run.sh` assertion (the verifier proves *file+name resolve*; only a human can confirm the *test logic* matches the original). This is the gate for §5.
+- [ ] 4.1 Produce `openspec/changes/migrate-tests-to-bats/parity.md` as a **fixed-shape line file** — NOT a markdown table. One assertion per line in the form `^N\. <file>:<test-name>$` (where N is the assertion number 1–14 from `specs/test-suite/spec.md` "Coverage parity"). Lines may be preceded by free-form prose (commentary, headings); the verifier ignores any line not matching the regex. This format makes the file both human-readable and trivially machine-parseable without reinventing markdown-table parsing. Cross-check entries against `run.sh` line numbers.
+- [ ] 4.2 Write the parity verifier per the spec's "Mechanized parity verification" requirement. **Implementation**: `scripts/tests/check-parity.sh` (bash). Single bash file under the shell-authoring 100-line threshold — straightforward grep + per-row check is well inside that budget. Must obey `#!/usr/bin/env bash`, set the strict-mode preamble, exit non-zero on any miss, and clear `shellcheck` (per the §1.3 CI step). The repo currently has no Python tooling (no `pyproject.toml`, no ruff config); a Python verifier would force adding ruff + a Python CI step, which is scope creep. Keep it bash. Add a CI step that runs this verifier ahead of `bats scripts/tests/bats/`. (Removed in §5 when `run.sh` is deleted.)
+- [ ] 4.3 Manual review: a maintainer confirms the parity file semantically captures every `run.sh` assertion (the verifier proves *file+name resolve*; only a human can confirm the *test logic* matches the original). This is the gate for §5.
 - [ ] 4.4 Verify bats suite passes under `--jobs 4` (parallel-safety check) at least once locally; do not enable in CI yet.
 
 ## 4b. Timing constraint
@@ -55,4 +55,4 @@ For each `.bats` file: write the file, run `bats <file>` locally, confirm it pas
 ## 7. Validate the change
 
 - [ ] 7.1 Run `openspec validate migrate-tests-to-bats --strict` and resolve any findings.
-- [ ] 7.2 Open the PR; ensure the parity table at §4.1 is linked in the description.
+- [ ] 7.2 Open the PR; ensure `parity.md` from §4.1 is linked in the description.


### PR DESCRIPTION
## Summary

- OpenSpec proposal to replace the 294-line hand-rolled `scripts/tests/run.sh` with a bats-core suite at full coverage parity (14 distinct assertions enumerated in the spec).
- Side-by-side migration over three PRs (helpers, all-tests, parity-and-delete) with a mechanized parity verifier in CI for the duration of the side-by-side window.
- Adds permanent `shellcheck` CI step for `scripts/*.sh` and `scripts/tests/bats/helpers/*.bash`.
- This PR contains **planning artifacts only** — no production code or tests yet. Reviewers should evaluate the migration plan; implementation lands in follow-up PRs.

## Artifacts

- `proposal.md` — why bats, scope, new `test-suite` capability, impact.
- `design.md` — 6 decisions (framework, file boundaries, helpers, side-by-side+delete, exit-code tightening, CI install) with alternatives, risks, bounded migration window, rollback.
- `specs/test-suite/spec.md` — 7 requirements: framework, layout, coverage parity (14 enumerated assertions mapped to `run.sh` line numbers), mechanized parity verifier, shell-script linting, CI invocation, legacy runner deletion.
- `tasks.md` — 7 task groups (~30 tasks): CI bootstrap, helpers, 9 per-concern `.bats` files, parity checkpoint (mechanized + manual + timing), cut over, docs, validate.

## Notable design choices (called out for review)

1. **One `.bats` per concern, not per script** — multiple production scripts share single test concerns (e.g., extension-id allowlist spans 3 scripts).
2. **Side-by-side then delete in the same change** — explicitly rejects "add bats now, delete `run.sh` in a follow-up." Bounded to 3 PRs to prevent indefinite drift.
3. **Mechanized parity verifier (\`scripts/tests/check-parity.{sh,py}\`)** — the parity table is also enforced by an executable check in CI, not just by manual review. Removed alongside `run.sh`.
4. **Spec-path resilience for assertion #12** — the `EXTENSION_ID_REGEX` literal lives in change-folder specs (`openspec/changes/harden-profile-tooling-and-pipeline/specs/...`) that may be archived. The bats test resolves `openspec/specs/<cap>/spec.md` first then falls back, surviving the archive.
5. **Tighten exit-code assertions during migration** — bats tests use `[ "$status" -eq <N> ]`, not the looser `-ne 0` pattern in `run.sh:130,190,208,216`.
6. **Permanent shellcheck step** — added alongside bats migration; survives `run.sh` deletion.

## Test plan

- [x] `openspec validate migrate-tests-to-bats --strict` passes (verified locally).
- [ ] Reviewer reads `proposal.md` and `design.md` and either approves the plan or requests scope changes.
- [ ] Reviewer scans `specs/test-suite/spec.md` "Coverage parity" requirement and confirms the 14 enumerated assertions match what `scripts/tests/run.sh` actually does today.
- [ ] Reviewer confirms the bounded window (3 PRs) is realistic given current contributor bandwidth, or proposes a different envelope.
- [ ] Implementation PRs reference this change via `tasks.md` and check off tasks as they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)